### PR TITLE
Refactoring to enable unit tests of JS helper functions

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -9,6 +9,8 @@
       "spec_fees.js",
       "spec_rescan.js",
       "spec_qr_signing.js",
+      "spec_formatting.js",
+      "spec_common.js",
       "spec_balances_amounts.js",
       "spec_wallet_send.js",
       "spec_wallet_utxo.js",

--- a/cypress/integration/spec_common.js
+++ b/cypress/integration/spec_common.js
@@ -1,0 +1,16 @@
+import { showNotification } from '../../src/cryptoadvance/specter/static/helper-modules/common.js'
+
+describe('Unit tests of common JS functions', () => {
+    before(() => {
+        cy.visit('/')
+    })
+
+    it('Test showNotification function', () => {
+        // Approach from: https://dzone.com/articles/how-to-execute-javascript-commands-in-cypress
+        cy.window().then((win) => {
+            win.eval('showNotification("New wallet created", timeout=2000)');
+        });
+        cy.get('message-box').should('have.text', 'New wallet created')
+    })
+    
+})

--- a/cypress/integration/spec_formatting.js
+++ b/cypress/integration/spec_formatting.js
@@ -1,0 +1,22 @@
+import { capitalize, numberWithCommas } from '../../src/cryptoadvance/specter/static/helper-modules/formatting.js'
+
+describe('Unit tests of formatting JS functions', () => {
+    before(() => {
+        cy.visit('/')
+    })
+
+    it('Test capitalize function', () => {
+        expect(capitalize('satoshi')).to.equal('Satoshi')
+        expect(capitalize('satoshi nakamoto')).to.equal('Satoshi nakamoto')
+    })
+
+    it('Test numberWithCommas function', () => {
+        expect(numberWithCommas('1000')).to.equal('1,000')
+        expect(numberWithCommas('1000000')).to.equal('1,000,000')
+        expect(numberWithCommas(1000)).to.equal('1,000')
+        expect(numberWithCommas(1000000)).to.equal('1,000,000')
+        expect(numberWithCommas('0.1')).to.equal('0.1')
+        expect(numberWithCommas(0.1)).to.equal('0.1')
+    })
+    
+})

--- a/cypress/integration/spec_wallet_send.js
+++ b/cypress/integration/spec_wallet_send.js
@@ -43,8 +43,8 @@ describe('Test sending transactions', () => {
         cy.get('.tx-data-info').contains('Address #0')
         cy.get('.tx-data-info').find('.tx_info').eq(0).contains('Value: 20.00000000 tBTC')
         cy.get('.tx-data-info').contains('Output #0')
-        cy.get('.tx-data-info').contains('Burn address') 
-        cy.get('.tx-data-info').find('.tx_info').eq(1).contains('Value: 19.99999890 tBTC')   // Fees should always be the same
+        cy.get('.tx-data-info').contains('Burn address')
+        cy.get('.tx-data-info').find('.tx_info').eq(1).contains(/Value:\s19\.9999\d{4}\stBTC/) // Fees change apparently
         cy.get('#page_overlay_popup_cancel_button').click()
         // Change to sats and check amounts and units
         cy.get('[href="/settings/"]').click()
@@ -54,7 +54,7 @@ describe('Test sending transactions', () => {
         cy.get('#btn_transactions').click()
         cy.get('tbody.tx-tbody').find('tr').eq(0).find('#column-txid').find('.explorer-link').click()
         cy.get('.tx-data-info').contains('Value: 2,000,000,000 tsat')
-        cy.get('.tx-data-info').contains('Value: 1,999,999,890 tsat')
+        cy.get('.tx-data-info').contains(/Value:\s1,999,99\d,\d{3}\stsat/) // Fees change apparently
         cy.get('#page_overlay_popup_cancel_button').click()
         // Change back to btc
         cy.get('[href="/settings/"]').click()

--- a/src/cryptoadvance/specter/static/helper-modules/common.js
+++ b/src/cryptoadvance/specter/static/helper-modules/common.js
@@ -1,0 +1,64 @@
+function copyText(value, msg) {
+	try {
+		var element = document.createElement("p");
+		document.getElementsByTagName("body")[0].appendChild(element);
+		element.textContent = value;
+		var selection = document.getSelection();
+		var range = document.createRange();
+		range.selectNodeContents(element);
+		selection.removeAllRanges();
+		selection.addRange(range);
+		document.execCommand("copy");
+		selection.removeAllRanges();
+		document.getElementsByTagName("body")[0].removeChild(element);
+		showNotification(msg);
+	}
+	catch (err) {
+		showError('Unable to copy text');
+	}
+}
+
+async function send_request(url, method_str, csrf_token, formData) {
+	if (!formData) {
+		formData = new FormData();
+	}
+	formData.append("csrf_token", csrf_token)
+	let d = {
+			method: method_str,
+		}
+	if (method_str == 'POST') {
+		d['body'] = formData;
+	}
+
+	const response = await fetch(url, d);
+	if(response.status != 200){
+		showError(await response.text());
+		console.log(`Error while calling ${url} with ${method_str} ${formData}`)
+		return
+	}
+	return await response.json();
+}
+
+function showError(msg, timeout=0) {
+	return showNotification(msg, timeout, "error");
+}
+
+function showNotification(msg, timeout=3000, type="primary") {
+	let el = document.createElement("message-box");
+	el.setAttribute("type", type);
+	el.setAttribute("timeout", timeout);
+	el.innerHTML = msg;
+	document.getElementById("messages").appendChild(el);
+	el.addEventListener('click', (e)=>{
+		document.getElementById("messages").removeChild(el);
+	});
+	return el;
+}
+
+async function wait(ms){
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+}
+
+export { copyText, send_request, showError, showNotification, wait }

--- a/src/cryptoadvance/specter/static/helper-modules/formatting.js
+++ b/src/cryptoadvance/specter/static/helper-modules/formatting.js
@@ -1,0 +1,13 @@
+function capitalize(str){
+	return str.charAt(0).toUpperCase()+str.substring(1);
+}
+
+function numberWithCommas(x) {
+	x = parseFloat(x).toString();
+	if (x.split(".").length > 1) {
+		return x.split(".")[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",") + '.' + x.split(".")[1];
+	}
+    return x.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export { capitalize, numberWithCommas }

--- a/src/cryptoadvance/specter/static/helper-modules/mobile.js
+++ b/src/cryptoadvance/specter/static/helper-modules/mobile.js
@@ -1,0 +1,13 @@
+// toggle a navbar on mobile view
+function toggleMobileNav(btn, openImg, collapseImg) {
+	var x = btn.parentNode;
+	if (x.className === "row collapse-on-mobile") {
+		x.className += " responsive";
+		btn.children[0].src = collapseImg;
+	} else {
+		x.className = "row collapse-on-mobile";
+		btn.children[0].src = openImg;
+	}
+}
+
+export { toggleMobileNav }

--- a/src/cryptoadvance/specter/static/helpers.js
+++ b/src/cryptoadvance/specter/static/helpers.js
@@ -1,7 +1,22 @@
+import { capitalize, numberWithCommas } from './helper-modules/formatting.js'
+import { copyText, send_request, showError, showNotification, wait } from './helper-modules/common.js'
+import { toggleMobileNav } from './helper-modules/mobile.js'
+
+// The scope of functions inside a module is not global, putting them on the window object makes them accessible outside of the module. 
+// See: https://stackoverflow.com/questions/44590393/es6-modules-undefined-onclick-function-after-import
+window.capitalize = capitalize
+window.numberWithCommas = numberWithCommas
+window.copyText = copyText
+window.send_request = send_request
+window.showError = showError
+window.showNotification = showNotification
+window.wait = wait
+window.toggleMobileNav = toggleMobileNav
+
 window.addEventListener('load', (event) => {
 	let main = document.getElementsByTagName("main")[0];
 	main.addEventListener('click', (event) => {
-		side_content = document.getElementById("side-content")
+		let side_content = document.getElementById("side-content")
 		if (side_content != null) {
 			side_content.classList.remove("active");
 		}
@@ -64,49 +79,6 @@ document.addEventListener("updateAddressLabel", function (e) {
 
 document.documentElement.style.setProperty('--mobileDistanceElementBottomHeight', `${Math.max(0, window.outerHeight - window.innerHeight)}px`);
 
-function showError(msg, timeout=0) {
-	return showNotification(msg, timeout, "error");
-}
-function showNotification(msg, timeout=3000, type="primary") {
-	let el = document.createElement("message-box");
-	el.setAttribute("type", type);
-	el.setAttribute("timeout", timeout);
-	el.innerHTML = msg;
-	document.getElementById("messages").appendChild(el);
-	el.addEventListener('click', (e)=>{
-		document.getElementById("messages").removeChild(el);
-	});
-	return el;
-}
-
-function copyText(value, msg) {
-	try {
-		var element = document.createElement("p");
-		document.getElementsByTagName("body")[0].appendChild(element);
-		element.textContent = value;
-		var selection = document.getSelection();
-		var range = document.createRange();
-		range.selectNodeContents(element);
-		selection.removeAllRanges();
-		selection.addRange(range);
-		document.execCommand("copy");
-		selection.removeAllRanges();
-		document.getElementsByTagName("body")[0].removeChild(element);
-		showNotification(msg);
-	}
-	catch (err) {
-		showError('Unable to copy text');
-	}
-}
-async function wait(ms){
-	return new Promise(resolve => {
-		setTimeout(resolve, ms);
-	});
-}
-function capitalize(str){
-	return str.charAt(0).toUpperCase()+str.substring(1);
-}
-
 // Enable navigation loader
 window.addEventListener('beforeunload', function (e) {
 	// half a second delay before we show it
@@ -114,45 +86,3 @@ window.addEventListener('beforeunload', function (e) {
 		document.getElementById("pageloader").style.display = 'block';
 	}, 200);
 });
-
-// toggle a navbar on mobile view
-function toggleMobileNav(btn, openImg, collapseImg) {
-	var x = btn.parentNode;
-	if (x.className === "row collapse-on-mobile") {
-		x.className += " responsive";
-		btn.children[0].src = collapseImg;
-	} else {
-		x.className = "row collapse-on-mobile";
-		btn.children[0].src = openImg;
-	}
-}
-
-function numberWithCommas(x) {
-	x = parseFloat(x).toString();
-	if (x.split(".").length > 1) {
-		return x.split(".")[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",") + '.' + x.split(".")[1];
-	}
-    return x.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
-
-
-async function send_request(url, method_str, csrf_token, formData) {
-	if (!formData) {
-		formData = new FormData();
-	}
-	formData.append("csrf_token", csrf_token)
-	d = {
-			method: method_str,
-		}
-	if (method_str == 'POST') {
-		d['body'] = formData;
-	}
-
-	const response = await fetch(url, d);
-	if(response.status != 200){
-		showError(await response.text());
-		console.log(`Error while calling ${url} with ${method_str} ${formData}`)
-		return
-	}
-	return await response.json();
-}

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -42,7 +42,7 @@
 				background: rgba(255,255,255,0.03);
 			}
 		</style>
-		<script type="text/javascript" src="{{ url_for('static', filename='helpers.js') }}"></script>
+		<script type="module" src="{{ url_for('static', filename='helpers.js') }}"></script>
 		{% include "includes/helpers.jinja" %}
 		{% include "services/inject_in_basejinja_head.jinja" %}
 		{% block head %}


### PR DESCRIPTION
After some research on how to implement JS unit tests with Cypress I came up with this PR. 

The structure is like so:

`helpers.js` - everything is brought together here and, importantly, made global since modules have a limited scope. This is done by: 
```
import { foo } from './module-a.js'
window.foo = foo
```

` helper-modules` (directory)
    -- `formatting.js`
    -- `common.js`
-- `mobile.js`

The only change in `base.jinja` is using the module type:
`<script type="module" src="{{ url_for('static', filename='helpers.js') }}"></script>`

In Cypress we can then just import the functions from the respective helper module:
`import { capitalize } from '../../src/cryptoadvance/specter/static/helper-modules/formatting.js'`
and test them:
```
describe('Unit tests of formatting JS functions', () => {
    it('Test capitalize function', () => {
        expect(capitalize('satoshi')).to.equal('Satoshi')
    })
```

One note on testing JS functions that rely on the window / document context, just applying them like the isolated formatting functions does not work. The following approach seems to work in Cypress. For more details, see: https://dzone.com/articles/how-to-execute-javascript-commands-in-cypress
```
    it('Test showNotification function', () => {
        cy.window().then((win) => {
            win.eval('showNotification("New wallet created", timeout=2000)');
        });
        cy.get('message-box').should('have.text', 'New wallet created')
    })
```